### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # test walks commit history; checkout@v6 defaults to a shallow clone
     - name: Install libgit2
       run: sudo apt-get install libgit2-dev
     - name: make

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v6
     - name: Install libgit2
       run: sudo apt-get install libgit2-dev
     - name: make


### PR DESCRIPTION
## What

Bump GitHub Actions to their Node-24-native majors to clear the Node-20 runtime deprecation. GitHub force-migrates deprecated (Node-20) actions to Node 24 on **2026-06-16**; pinning ahead avoids surprise behaviour changes.

## Bump map

| action | after |
|---|---|
| actions/checkout | v6 |
| actions/setup-go | v6 |
| actions/setup-node | v6 |
| actions/cache | v5 |
| actions/setup-java | v5 |
| actions/setup-python | v6 |
| actions/upload-artifact | v7 |
| actions/download-artifact | v8 |

upload/download bumped as a matched pair (v7 ↔ v8) so the artifact handshake stays compatible.

Part of 🎯T4 (fleet-wide Actions deprecation sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)